### PR TITLE
stopwatch, lower oneliner, ignore missions

### DIFF
--- a/QuickStart/Lang/en-us.cfg
+++ b/QuickStart/Lang/en-us.cfg
@@ -15,16 +15,17 @@
                 quickstart_cancelAssign = Cancel Assignment
                 quickstart_set = Set
                 quickstart_keyShortcuts = Keyboard Shortcuts
-                quickstart_lastGame = [<<1>>] Last game found: <color=white><b><<2>></b></color>
-                quickstart_noLastGame = [<<1>>] <b><color=#000000>No last game found</color></b>
+                quickstart_lastGame = Save: <color=white><b><<1>></b></color>
+                quickstart_noLastGame = <b><color=white>Saves isn't found</color></b>
                 quickstart_enable = Enable <<1>>
-                quickstart_sc = Space Center
-                quickstart_vab = Vehicle Assembly Building
-                quickstart_sph = Space Plane Hangar
+                quickstart_sc = KSC
+                quickstart_vab = VAB
+                quickstart_sph = SPH
                 quickstart_ts = Tracking Station
                 quickstart_autoSaveShip = Auto Save Ship on Editor
                 quickstart_loadLastShip = Auto Load the Last Saved Ship
                 quickstart_pauseLoad = Pause the Flight at Load
+				
                 quickstart_saveEach = Save each seconds:
                 quickstart_waitLoading = Wait after Loading in seconds:
                 quickstart_lastVessel = Last Vessel <<1>>(<<2>>)
@@ -32,5 +33,10 @@
                 quickstart_stop = Stop <<1>>
                 quickstart_abort = Push on <<1>> to abort the operation
                 quickstart_noVessel = No vessel found
+
+				quickstart_enableStopWatch = Show a stopwatch
+				quickstart_stopWatch = [T+<<1>>:<<2>>]
+				quickstart_skipping = Skipping <<1>>
+				quickstart_mainMenu = MainMenu
         }
 }

--- a/QuickStart/Lang/en-us.cfg
+++ b/QuickStart/Lang/en-us.cfg
@@ -25,7 +25,7 @@
                 quickstart_autoSaveShip = Auto Save Ship on Editor
                 quickstart_loadLastShip = Auto Load the Last Saved Ship
                 quickstart_pauseLoad = Pause the Flight at Load
-				
+
                 quickstart_saveEach = Save each seconds:
                 quickstart_waitLoading = Wait after Loading in seconds:
                 quickstart_lastVessel = Last Vessel <<1>>(<<2>>)
@@ -34,9 +34,9 @@
                 quickstart_abort = Push on <<1>> to abort the operation
                 quickstart_noVessel = No vessel found
 
-				quickstart_enableStopWatch = Show a stopwatch
-				quickstart_stopWatch = [T+<<1>>:<<2>>]
-				quickstart_skipping = Skipping <<1>>
-				quickstart_mainMenu = MainMenu
+                quickstart_enableStopWatch = Show a stopwatch
+                quickstart_stopWatch = [T+<<1>>:<<2>>]
+                quickstart_skipping = Skipping <<1>>
+                quickstart_mainMenu = MainMenu
         }
 }

--- a/QuickStart/Lang/fr-fr.cfg
+++ b/QuickStart/Lang/fr-fr.cfg
@@ -32,9 +32,9 @@
                 quickstart_stop = Arrêter <<1>>
                 quickstart_abort = Appuyez sur <<1>> pour annuler l'action
 
-				quickstart_enableStopWatch = Show a stopwatch
-				quickstart_stopWatch = [T+<<1>>:<<2>>]
-				quickstart_skipping = Skipping <<1>>
-				quickstart_mainMenu = MainMenu
+                quickstart_enableStopWatch = Show a stopwatch
+                quickstart_stopWatch = [T+<<1>>:<<2>>]
+                quickstart_skipping = Skipping <<1>>
+                quickstart_mainMenu = MainMenu
         }
 }

--- a/QuickStart/Lang/fr-fr.cfg
+++ b/QuickStart/Lang/fr-fr.cfg
@@ -15,12 +15,12 @@
                 quickstart_cancelAssign = Annuler l'affectation
                 quickstart_set = Assigner
                 quickstart_keyShortcuts = Keyboard Shortcuts
-                quickstart_lastGame = [<<1>>] Dernière partie trouvée : <color=white><b><<2>></b></color>
-                quickstart_noLastGame = [<<1>>] <b><color=#000000>Pas de sauvegarde trouvée</color></b>
+                quickstart_lastGame = Dernière partie trouvée : <color=white><b><<1>></b></color>
+                quickstart_noLastGame = <b><color=#000000>Pas de sauvegarde trouvée</color></b>
                 quickstart_enable = Activer <<1>>
-                quickstart_sc = Centre Spatial
-                quickstart_vab = Bâtiment d'assemblage
-                quickstart_sph = Hangar d'avion de l'espace
+                quickstart_sc = KSC // CSK  // Centre Spatial
+                quickstart_vab = VAB // BAV // Bâtiment d'assemblage
+                quickstart_sph = SPH // HAS // Hangar d'avion de l'espace
                 quickstart_ts = Station de suivis
                 quickstart_autoSaveShip = Sauvegarder automatiquement le vaisseau dans l'éditeur
                 quickstart_loadLastShip = Charger automatiquement le dernier vaisseau
@@ -31,5 +31,10 @@
                 quickstart_blackScreen = Ecran noir lorsqu'il attend
                 quickstart_stop = Arrêter <<1>>
                 quickstart_abort = Appuyez sur <<1>> pour annuler l'action
+
+				quickstart_enableStopWatch = Show a stopwatch
+				quickstart_stopWatch = [T+<<1>>:<<2>>]
+				quickstart_skipping = Skipping <<1>>
+				quickstart_mainMenu = MainMenu
         }
 }

--- a/QuickStart/QS_Loading.cs
+++ b/QuickStart/QS_Loading.cs
@@ -21,7 +21,6 @@ using QuickStart.QUtils;
 using KSP.Localization;
 
 using ClickThroughFix;
-using System.Collections.Generic;
 
 namespace QuickStart {
 
@@ -30,7 +29,7 @@ namespace QuickStart {
 		[KSPField (isPersistant = true)] public static bool Ended = false;
 
 		internal bool WindowSettings = false;
-        private string StopWatchText = "";
+		private string StopWatchText = "";
 
 		Rect rectSettings = new Rect ();
 		Rect RectSettings {

--- a/QuickStart/QS_Loading.cs
+++ b/QuickStart/QS_Loading.cs
@@ -21,21 +21,23 @@ using QuickStart.QUtils;
 using KSP.Localization;
 
 using ClickThroughFix;
+using System.Collections.Generic;
 
 namespace QuickStart {
 
-	public partial class QLoading {
+    public partial class QLoading {
 
 		[KSPField (isPersistant = true)] public static bool Ended = false;
 
 		internal bool WindowSettings = false;
+        private string StopWatchText = "";
 
 		Rect rectSettings = new Rect ();
 		Rect RectSettings {
 			get {
                 if (rectSettings.position == Vector2.zero && rectSettings.size != Vector2.zero) {
                     rectSettings.x = Screen.width - rectSettings.width;
-                    rectSettings.y = Screen.width < 1440 ? 100 : Screen.height - rectSettings.height - 100;
+                    rectSettings.y = Screen.height - rectSettings.height - 100;
                 }
 				return rectSettings;
 			}
@@ -46,7 +48,7 @@ namespace QuickStart {
 
 		Rect RectGUI {
 			get {
-				return new Rect (0, Screen.width < 1440 ? 0 : Screen.height - 50, Screen.width, 100);
+				return new Rect (0, Screen.height - 50, Screen.width, 100);
 			}
 		}
 
@@ -86,12 +88,18 @@ namespace QuickStart {
 			}
             QKey.VerifyKey();
 			QDebug.Log ("Start", "QLoading");
-		}
+
+            InvokeRepeating("UpdateStopWatch", 0, 1.0f);
+        }
 
 		void OnDestroy() {
 			QSettings.Instance.Save ();
 			QDebug.Log ("OnDestroy", "QLoading");
 		}
+
+        void UpdateStopWatch() {
+            StopWatchText = QuickStart_Persistent.StopWatchText;
+        }
 
         void Update() {
             if (QKey.SetKey()) {
@@ -110,7 +118,16 @@ namespace QuickStart {
 			QDebug.Log ("Settings", "QGUI");
 		}
 
-		void OnGUI() {
+        static class LabelWidth {
+            public static GUILayoutOption Enabled { get; } = GUILayout.Width(200);
+            public static GUILayoutOption KSC { get; } = GUILayout.Width(100);
+            public static GUILayoutOption VAB { get; } = GUILayout.Width(100);
+            public static GUILayoutOption SPH { get; } = GUILayout.Width(100);
+            public static GUILayoutOption TrackingStation { get; } = GUILayout.Width(200);
+            public static GUILayoutOption Vessel { get; } = GUILayout.Width(250);
+        };
+
+        void OnGUI() {
 			if (HighLogic.LoadedScene != GameScenes.LOADING) {
 				return;
 			}
@@ -128,63 +145,63 @@ namespace QuickStart {
 			GUILayout.BeginArea (RectGUI);
 			GUILayout.BeginVertical ();
 			GUILayout.BeginHorizontal ();
-			if (QSettings.Instance.Enabled) {
+            GUILayout.Label(StopWatchText);
+
+            if (QSettings.Instance.Enabled) {
                 GUILayout.Label(!string.IsNullOrEmpty(QSaveGame.LastUsed) ?
-                                                     Localizer.Format("quickstart_lastGame", QuickStart.MOD, QSaveGame.LastUsed) :
-                                                     Localizer.Format("quickstart_noLastGame", QuickStart.MOD));
+                                                     Localizer.Format("quickstart_lastGame", QSaveGame.LastUsed) :
+                                                     Localizer.Format("quickstart_noLastGame"));
 				if (GUILayout.Button ("►", QStyle.Button, GUILayout.Width (20), GUILayout.Height (20))) {
 					QSaveGame.Next ();
 				}
 			}
 			GUILayout.FlexibleSpace ();
-            if (GUILayout.Button (Localizer.Format("quickstart_settings"), QStyle.Button, GUILayout.Height (20))) {
-				Settings ();
-			}
 			GUILayout.EndHorizontal ();
+
 			if (!string.IsNullOrEmpty (QSaveGame.LastUsed)) {
 				GUILayout.BeginHorizontal ();
-				QSettings.Instance.Enabled = GUILayout.Toggle (QSettings.Instance.Enabled, Localizer.Format("quickstart_enable", QuickStart.MOD), GUILayout.Width (250));
+				QSettings.Instance.Enabled = GUILayout.Toggle (QSettings.Instance.Enabled, Localizer.Format("quickstart_enable", QuickStart.MOD), LabelWidth.Enabled);
 				if (QSettings.Instance.Enabled) {
-					GUILayout.FlexibleSpace ();
-					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.SPACECENTER, Localizer.Format("quickstart_sc"), GUILayout.Width (250))) {
+					//GUILayout.FlexibleSpace ();
+					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.SPACECENTER, Localizer.Format("quickstart_sc"), LabelWidth.KSC)) {
 						if (QSettings.Instance.gameScene != (int)GameScenes.SPACECENTER) {
 							QSettings.Instance.gameScene = (int)GameScenes.SPACECENTER;
 						}
 					}
-					GUILayout.FlexibleSpace ();
-					if (GUILayout.Toggle (QSettings.Instance.editorFacility == (int)EditorFacility.VAB && QSettings.Instance.gameScene == (int)GameScenes.EDITOR, Localizer.Format("quickstart_vab"), GUILayout.Width (250))) {
+					//GUILayout.FlexibleSpace ();
+					if (GUILayout.Toggle (QSettings.Instance.editorFacility == (int)EditorFacility.VAB && QSettings.Instance.gameScene == (int)GameScenes.EDITOR, Localizer.Format("quickstart_vab"), LabelWidth.VAB)) {
 						if (QSettings.Instance.gameScene != (int)GameScenes.EDITOR || QSettings.Instance.editorFacility != (int)EditorFacility.VAB) {
 							QSettings.Instance.gameScene = (int)GameScenes.EDITOR;
 							QSettings.Instance.editorFacility = (int)EditorFacility.VAB;
 						}
 					}
-					if (Screen.width < 1440) {
-						GUILayout.EndHorizontal ();
-						GUILayout.BeginHorizontal ();
-					}
-					else {
-						GUILayout.FlexibleSpace ();
-					}
-					if (GUILayout.Toggle (QSettings.Instance.editorFacility == (int)EditorFacility.SPH && QSettings.Instance.gameScene == (int)GameScenes.EDITOR, Localizer.Format("quickstart_sph"), GUILayout.Width (250))) {
+					//GUILayout.FlexibleSpace ();
+					if (GUILayout.Toggle (QSettings.Instance.editorFacility == (int)EditorFacility.SPH && QSettings.Instance.gameScene == (int)GameScenes.EDITOR, Localizer.Format("quickstart_sph"), LabelWidth.SPH)) {
 						if (QSettings.Instance.gameScene != (int)GameScenes.EDITOR || QSettings.Instance.editorFacility != (int)EditorFacility.SPH) {
 							QSettings.Instance.gameScene = (int)GameScenes.EDITOR;
 							QSettings.Instance.editorFacility = (int)EditorFacility.SPH;
 						}
 					}
-					GUILayout.FlexibleSpace ();
-					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.TRACKSTATION, Localizer.Format("quickstart_ts"), GUILayout.Width (250))) {
+					//GUILayout.FlexibleSpace ();
+					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.TRACKSTATION, Localizer.Format("quickstart_ts"), LabelWidth.TrackingStation)) {
 						if (QSettings.Instance.gameScene != (int)GameScenes.TRACKSTATION) {
 							QSettings.Instance.gameScene = (int)GameScenes.TRACKSTATION;
 						}
 					}
-					GUILayout.FlexibleSpace ();
+					//GUILayout.FlexibleSpace ();
 					GUI.enabled = !string.IsNullOrEmpty (QuickStart_Persistent.vesselID);
-					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.FLIGHT, (!string.IsNullOrEmpty (QSaveGame.vesselName) ? Localizer.Format("quickstart_lastVessel", QSaveGame.vesselName, QSaveGame.vesselType) : Localizer.Format("quickstart_noVessel")), GUILayout.Width (250))) {
+					if (GUILayout.Toggle (QSettings.Instance.gameScene == (int)GameScenes.FLIGHT, (!string.IsNullOrEmpty (QSaveGame.vesselName) ? Localizer.Format("quickstart_lastVessel", QSaveGame.vesselName, QSaveGame.vesselType) : Localizer.Format("quickstart_noVessel")), LabelWidth.Vessel)) {
 						if (QSettings.Instance.gameScene != (int)GameScenes.FLIGHT) {
 							QSettings.Instance.gameScene = (int)GameScenes.FLIGHT;
 						}
 					}
-				}
+                    GUI.enabled = true;
+                    GUILayout.FlexibleSpace();
+                    if (GUILayout.Button(Localizer.Format("quickstart_settings"), QStyle.Button, GUILayout.Height(20)))
+                    {
+                        Settings();
+                    }
+                }
 				GUILayout.EndHorizontal ();
 			}
 			GUILayout.EndVertical ();
@@ -197,6 +214,10 @@ namespace QuickStart {
 			GUILayout.BeginHorizontal ();
 			GUILayout.Box (Localizer.Format("quickstart_options"), GUILayout.Height (30));
 			GUILayout.EndHorizontal ();
+
+            GUILayout.BeginHorizontal();
+            QSettings.Instance.enableStopWatch = GUILayout.Toggle(QSettings.Instance.enableStopWatch, Localizer.Format("quickstart_enableStopWatch"), GUILayout.Width(400));
+            GUILayout.EndHorizontal();
 
 			GUILayout.BeginHorizontal ();
 			GUILayout.Label (Localizer.Format("quickstart_waitLoading"), GUILayout.Width (300));
@@ -234,6 +255,9 @@ namespace QuickStart {
 			GUILayout.BeginHorizontal ();
 			QSettings.Instance.enablePauseOnFlight = GUILayout.Toggle (QSettings.Instance.enablePauseOnFlight, Localizer.Format("quickstart_pauseLoad"), GUILayout.Width (400));
 			GUILayout.EndHorizontal ();
+
+
+
             QKey.DrawConfigKey();
 			GUILayout.FlexibleSpace ();
 			GUILayout.BeginHorizontal ();

--- a/QuickStart/QS_MainMenu.cs
+++ b/QuickStart/QS_MainMenu.cs
@@ -125,12 +125,7 @@ namespace QuickStart {
 		}
 
 		void OnGUI() {
-			if (HighLogic.LoadedScene != GameScenes.MAINMENU) {
-				return;
-			}
-			GUILayout.BeginArea (new Rect (0, 0, Screen.width, Screen.height), QStyle.Label);
-            GUILayout.Label(QuickStart.MOD + "..." + Environment.NewLine + Localizer.Format("quickstart_abort", QSettings.Instance.KeyEscape), QStyle.Label);
-            GUILayout.EndArea ();
+			QuickStart_Persistent.SkippingScreen(GameScenes.MAINMENU, Localizer.Format("quickstart_mainMenu"));
 		}
 	}
 }

--- a/QuickStart/QS_Persistent.cs
+++ b/QuickStart/QS_Persistent.cs
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
 using System.Collections;
+using KSP.Localization;
 using QuickStart.QUtils;
 using UnityEngine;
 
@@ -38,6 +39,32 @@ namespace QuickStart {
 				return new Guid (vesselID);
 			}
 		}
+
+		public static String StopWatchText {
+			get {
+				if (QSettings.Instance.enableStopWatch) {
+					float RunningTime = Time.realtimeSinceStartup;
+					int min = (int)(RunningTime / 60f);
+					int sec = (int)(RunningTime) % 60;
+
+					return Localizer.Format("quickstart_stopWatch", min.ToString("00"), sec.ToString("00")) + " ";
+				}
+				else {
+					return "";
+				}
+			}
+		}
+
+		public static void SkippingScreen(GameScenes scene, string scene_name) {
+			if (HighLogic.LoadedScene != scene || QLoading.Ended) return;
+
+			GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height), QStyle.Label);
+			GUILayout.Label(QuickStart.MOD + Environment.NewLine
+				+ StopWatchText + Localizer.Format("quickstart_skipping", scene_name) + Environment.NewLine
+				+ Localizer.Format("quickstart_abort", QSettings.Instance.KeyEscape), QStyle.Label);
+			GUILayout.EndArea();
+		}
+
 
 		public static readonly string shipFilename = "Auto-Saved Ship";
 

--- a/QuickStart/QS_Settings.cs
+++ b/QuickStart/QS_Settings.cs
@@ -60,7 +60,8 @@ namespace QuickStart {
 		[Persistent] internal bool enableEditorAutoSaveShip = true;
 		[Persistent] internal bool enableEditorLoadAutoSave = true;
 		[Persistent] internal bool enablePauseOnFlight = true;
-        [Persistent] internal bool enableBlackScreen = true;
+		[Persistent] internal bool enableBlackScreen = true;
+		[Persistent] internal bool enableStopWatch = true;
 		[Persistent] internal int gameScene = (int)GameScenes.SPACECENTER;
 		[Persistent] internal int editorFacility = (int)EditorFacility.VAB;
 

--- a/QuickStart/QS_SpaceCenter.cs
+++ b/QuickStart/QS_SpaceCenter.cs
@@ -136,12 +136,7 @@ namespace QuickStart {
 		}
 
 		protected void OnGUI() {
-			if (HighLogic.LoadedScene != GameScenes.SPACECENTER || QLoading.Ended) {
-				return;
-			}
-			GUILayout.BeginArea (new Rect (0, 0, Screen.width, Screen.height), QStyle.Label);
-            GUILayout.Label (QuickStart.MOD + "..." + Environment.NewLine + Localizer.Format("quickstart_abort", QSettings.Instance.KeyEscape), QStyle.Label);
-			GUILayout.EndArea ();
+            QuickStart_Persistent.SkippingScreen(GameScenes.SPACECENTER, Localizer.Format("#autoLOC_148273").Replace(" ", ""));
 		}
 	}
 }

--- a/QuickStart/Utils/SaveGame.cs
+++ b/QuickStart/Utils/SaveGame.cs
@@ -46,7 +46,8 @@ namespace QuickStart.QUtils {
 
         public static string[] gameBlackList = {
             "scenarios",
-            "training"
+            "training",
+            "missions"
         };
 
         static bool isBlackList(string game) {


### PR DESCRIPTION
 * added a stopwatch to the loading screen and two skipping screens
     * added an option to the settings for hiding the stopwatch
 * showed which window is skipped on the skipping screens
 * reduced text
      * removed duplicating QuickStart name on the Loading screen
      * "Last game found:" changed to just "Save:" because switcher  `►` allows to change a loading save to not the last found
 * fixed hiding QuickStart behind AVC 
      * QuickStart is showed always as the bottom oneliner
      * used abbr. KSC, VAB, SPH
      * buttons are tighter (no FlexibleSpace)
 * added "missions" folder to the gameBlackList

------

 * 1280x720  
     loading screen - https://i.imgur.com/EWgR1jJ.png
 * FullHD
     loading screen - https://i.imgur.com/3kO8Dy8.jpg
     skipping screen - https://i.imgur.com/yEZ7eE0.png
 * Are all ok on the 4K?

