### PR TITLE
QS: Only enable history window if allowed

### DIFF
--- a/QuickSearch/QS_GUI.cs
+++ b/QuickSearch/QS_GUI.cs
@@ -140,7 +140,10 @@ namespace QuickSearch {
 			if (WindowHistory) {
 				return;
 			}
-			WindowHistory = true;
+            if (!QSettings.Instance.enableHistory)
+                return;
+
+            WindowHistory = true;
 			QDebug.Log ("ShowHistory", "QGUI");
 		}
 


### PR DESCRIPTION
Long standing bug where the history window was shown no matter what you had set. This fixes that bug.