### PR TITLE
Limit duplicate DLL warning to affected game versions

### DIFF
--- a/ZeroMiniAVC/ZeroMiniAVC/ZeroMiniAVC.cs
+++ b/ZeroMiniAVC/ZeroMiniAVC/ZeroMiniAVC.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
 ZeroMiniAVC
 Copyright 2017 Malah
 
@@ -99,6 +99,11 @@ namespace ZeroMiniAVC
 
             cleanMiniAVC();
 
+            if (affectedByDuplicateDLLBug())
+            {
+                duplicateDLLWarning();
+            }
+
             if (!prune && !delete)
             {
                 cleanData();
@@ -153,6 +158,19 @@ namespace ZeroMiniAVC
                     DoCleanup(_assembly.path);
                 }
             }
+        }
+
+        private bool affectedByDuplicateDLLBug()
+        {
+            // The duplicate DLL bug first appeared in KSP 1.12.0 and was fixed in 1.12.3
+            return Versioning.version_major == 1
+                && Versioning.version_minor == 12
+                && Versioning.Revision >= 0
+                && Versioning.Revision <= 2;
+        }
+
+        private void duplicateDLLWarning()
+        {
             FindAllDLLs();
             if (duplicateDlls.Count > 0)
                 this.gameObject.AddComponent<IssueGui>();


### PR DESCRIPTION
Hi @linuxgurugamer,

The duplicate DLL bug was [fixed in KSP 1.12.3](https://wiki.kerbalspaceprogram.com/wiki/1.12.3#Bugfixes), but current ZeroMiniAVC still complains to users as if it was present in current game versions. This causes headaches for users and other mod authors, see [your forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/174445-112x-malahs-quick-mods-important-update-for-zerominiavc/page/14/) and KSP-CKAN/NetKAN#9435.

This pull request adds a version check before the duplicate DLL checks are made. If the user is on KSP 1.12.0, 1.12.1, or 1.12.2 (in which duplicate DLLs crash the game), the warning appears as before. If they're on any other version (where duplicate DLLs don't crash the game), it doesn't appear.

Cheers!