### PR TITLE
Be extra sure that master volume is clamped between 0 and 1, set master volume to 1 by default

### DIFF
--- a/QuickMute/Object/QVolume.cs
+++ b/QuickMute/Object/QVolume.cs
@@ -66,10 +66,10 @@ namespace QuickMute.Object {
 
         public void Restore() {
             if (GameSettings.Ready) {
-                GameSettings.MASTER_VOLUME = master;
+                GameSettings.MASTER_VOLUME = Mathf.Clamp(master, 0, 1);
                 GameSettings.SaveSettings();
             } else {
-                QSettings.Instance.Master = master;
+                QSettings.Instance.Master = Mathf.Clamp(master, 0, 1);
                 QSettings.Instance.Save();
             }
         }

--- a/QuickMute/QM_Settings.cs
+++ b/QuickMute/QM_Settings.cs
@@ -44,7 +44,7 @@ namespace QuickMute {
         [Persistent] internal bool Level = true;
         [Persistent] internal bool Muted = false;
         [Persistent] internal bool ScrollLevel = true;
-        [Persistent] internal float Master = 0.5;
+        [Persistent] internal float Master = 1;
 
 		public void Save() {
 			ConfigNode _temp = ConfigNode.CreateConfigFromObject(this, new ConfigNode());

--- a/QuickMute/QM_Settings.cs
+++ b/QuickMute/QM_Settings.cs
@@ -44,7 +44,7 @@ namespace QuickMute {
         [Persistent] internal bool Level = true;
         [Persistent] internal bool Muted = false;
         [Persistent] internal bool ScrollLevel = true;
-        [Persistent] internal float Master = 0;
+        [Persistent] internal float Master = 0.5;
 
 		public void Save() {
 			ConfigNode _temp = ConfigNode.CreateConfigFromObject(this, new ConfigNode());


### PR DESCRIPTION
If I am reading this correctly, the code only checks to see if the master volume from the game settings is clamped between 0 and 1, and not if the master volume from the config is correct. This PR makes sure that both are checked.

Additionally, set the master volume default to 1, as it is already unmuted by default in the settings. This also serves to remind any dumb people poking around in the Config.txt (ahem, me) that the volume is on a scale from 0 to 1, and not 0 to 100.

Helps to prevent https://github.com/linuxgurugamer/QuickMods/issues/24



There's a fair amount of different places where this extra check could have been placed, so it's possible that I've put it in the wrong place. Please correct me if this is wrong.