### PR TITLE
Add UI_Scale for shifting QuickGoTo button

### DIFF
--- a/QuickGoTo/QG_GUI.cs
+++ b/QuickGoTo/QG_GUI.cs
@@ -188,9 +188,9 @@ namespace QuickGoTo
             get
             {
                 if (RP1isInstalled)
-                    rectButton.x = Screen.width - 120 * GameSettings.UI_SCALE;
+                    rectButton.x = Screen.width - 120 * Math.Max(1f, GameSettings.UI_SCALE);
                 else
-                    rectButton.x = Screen.width - 90 * GameSettings.UI_SCALE;
+                    rectButton.x = Screen.width - 90 * Math.Max(1f, GameSettings.UI_SCALE);
                 return rectButton;
             }
             set

--- a/QuickGoTo/QG_GUI.cs
+++ b/QuickGoTo/QG_GUI.cs
@@ -188,9 +188,9 @@ namespace QuickGoTo
             get
             {
                 if (RP1isInstalled)
-                    rectButton.x = Screen.width - 120;
+                    rectButton.x = Screen.width - 120 * GameSettings.UI_SCALE;
                 else
-                    rectButton.x = Screen.width - 90;
+                    rectButton.x = Screen.width - 90 * GameSettings.UI_SCALE;
                 return rectButton;
             }
             set


### PR DESCRIPTION
Fix https://github.com/linuxgurugamer/QuickMods/issues/28#issuecomment-3042270863.

I used Math.Max because it started to overlap below 100% UI scale.

Not really sure what problem I had with building last time, this went fine.


Test Pictures: (1440p monitor)
130%
![image](https://github.com/user-attachments/assets/ccd224ff-e7eb-4c34-be22-083fede02907)

100%
![image](https://github.com/user-attachments/assets/027f6496-d6e3-49fc-a3ef-20c827b5b604)

80%
![image](https://github.com/user-attachments/assets/9050ca92-e411-4449-85ea-cf217e3e5c1b)

200%
![image](https://github.com/user-attachments/assets/364c84af-a4b7-44cb-ad8c-9befa3a4269e)
 


(need to test with stock, should be fine tho)